### PR TITLE
Honor inputAttrs:id

### DIFF
--- a/backbone-formview.js
+++ b/backbone-formview.js
@@ -836,7 +836,7 @@
          * @return {string}
          */
         _getInputId : function () {
-            return this.options.inputId || this.inputId ||
+            return this.options.inputId || this.inputId || (this.options.inputAttrs && this.options.inputAttrs.id) ||
                 this.inputPrefix + this._getParentPrefix() + this.fieldName;
         },
         /**


### PR DESCRIPTION
When someone passes options with inputAttrs that include
an id, honor it. Still defers to `options.inputId` or `inputId`